### PR TITLE
Limits upper index in URL.

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -21,7 +21,7 @@
   function navigate(by) {
     var index = (parseInt(document.location.hash.slice(1), 10) || 0) + by;
 
-    if (index < 0) {
+    if (index < 0 || index >= templates.length) {
       return;
     }
 


### PR DESCRIPTION
The slide deck already had a lower index limit in the URL of 0. This fix stops the index incrementing beyond the slide deck.
